### PR TITLE
Add visibility option to inlays

### DIFF
--- a/BrowserHost.Plugin/Configuration.cs
+++ b/BrowserHost.Plugin/Configuration.cs
@@ -18,6 +18,7 @@ namespace BrowserHost.Plugin
 		public Guid Guid;
 		public string Name;
 		public string Url;
+		public bool Visible;
 		public bool Locked;
 		public bool ClickThrough;
 	}

--- a/BrowserHost.Plugin/Inlay.cs
+++ b/BrowserHost.Plugin/Inlay.cs
@@ -73,7 +73,7 @@ namespace BrowserHost.Plugin
 				WindowsMessage.WM_SYSKEYUP => KeyEventType.KeyUp,
 				WindowsMessage.WM_CHAR => KeyEventType.Character,
 				WindowsMessage.WM_SYSCHAR => KeyEventType.Character,
-				_ => null,
+				_ => (KeyEventType?) null,
 			};
 
 			// If the event isn't something we're tracking, bail early with no capture
@@ -111,6 +111,9 @@ namespace BrowserHost.Plugin
 
 		public void Render()
 		{
+			if (!Config.Visible)
+				return;
+
 			ImGui.SetNextWindowSize(new Vector2(640, 480), ImGuiCond.FirstUseEver);
 			ImGui.Begin($"{Config.Name}###{Config.Guid}", GetWindowFlags());
 

--- a/BrowserHost.Plugin/Settings.cs
+++ b/BrowserHost.Plugin/Settings.cs
@@ -37,7 +37,8 @@ namespace BrowserHost.Plugin
 			pluginInterface.UiBuilder.OnOpenConfigUi += (sender, args) => open = true;
 			pluginInterface.CommandManager.AddHandler("/pbrowser", new CommandInfo(HandleCommand)
 			{
-				HelpMessage = "Open BrowserHost configuration pane.",
+				HelpMessage = "Open BrowserHost configuration pane with '/pbrowser', or change the visibility of an inlay with " +
+				              "'/pbrowser [show,hide,toggle] <inlay name>'.",
 				ShowInHelp = true,
 			});
 		}

--- a/BrowserHost.Plugin/Settings.cs
+++ b/BrowserHost.Plugin/Settings.cs
@@ -6,6 +6,7 @@ using System;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Game.Internal.Gui;
 
 namespace BrowserHost.Plugin
 {
@@ -34,11 +35,54 @@ namespace BrowserHost.Plugin
 			this.pluginInterface = pluginInterface;
 
 			pluginInterface.UiBuilder.OnOpenConfigUi += (sender, args) => open = true;
-			pluginInterface.CommandManager.AddHandler("/pbrowser", new CommandInfo((command, arguments) => open = true)
+			pluginInterface.CommandManager.AddHandler("/pbrowser", new CommandInfo(HandleCommand)
 			{
 				HelpMessage = "Open BrowserHost configuration pane.",
 				ShowInHelp = true,
 			});
+		}
+
+		public void HandleCommand(string command, string arguments)
+		{
+			if (arguments == string.Empty)
+			{
+				// Just show the UI.
+				open = true;
+				return;
+			}
+
+			string[] args = arguments.Split(new [] {' '}, 2);
+
+			if (args.Length != 2)
+				// Invalid...
+				return;
+
+			InlayConfiguration targetInlay;
+			try
+			{
+				targetInlay = config.Inlays.Find(i => i.Name == args[1]);
+			}
+			catch (ArgumentNullException)
+			{
+				// Invalid inlay name
+				return;
+			}
+
+			switch (args[0])
+			{
+				case "show":
+					targetInlay.Visible = true;
+					break;
+				case "hide":
+					targetInlay.Visible = false;
+					break;
+				case "toggle":
+					targetInlay.Visible = !targetInlay.Visible;
+					break;
+				default:
+					// Invalid action
+					break;
+			}
 		}
 
 		public void Initialise()

--- a/BrowserHost.Plugin/Settings.cs
+++ b/BrowserHost.Plugin/Settings.cs
@@ -211,6 +211,10 @@ namespace BrowserHost.Plugin
 			dirty |= ImGui.Checkbox("Click Through", ref inlayConfig.ClickThrough);
 			if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Prevent the inlay from intecepting any mouse events."); }
 
+			ImGui.SameLine();
+			dirty |= ImGui.Checkbox("Visible", ref inlayConfig.Visible);
+			if (ImGui.IsItemHovered()) { ImGui.SetTooltip("Show the inlay."); }
+
 			if (ImGui.Button("Reload")) { ReloadInlay(inlayConfig); }
 
 			ImGui.SameLine();


### PR DESCRIPTION
I often found myself wanting to hide or show inlays via macros, so I added an option to the Inlay class and created a handler for the command to allow for hiding and showing.

(Sorry for the weird redundant cast on `BrowserHost.Plugin/Inlay.cs:76`, I had to do it to get the plugin to compile).